### PR TITLE
feat: include playwright-mcp repository in board queries

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,12 +109,12 @@ export async function getData(): Promise<{ issues: Ticket[], pullRequests: Ticke
     }
       
     query {
-      issues: search(query: "(repo:microsoft/playwright OR repo:microsoft/playwright-mcp) state:open no:label is:issue", type: ISSUE, first: 100) {
+      issues: search(query: "repo:microsoft/playwright repo:microsoft/playwright-mcp state:open no:label is:issue", type: ISSUE, first: 100) {
         nodes {
           ... on Issue { ...IssueParts }
         }
       }
-      pullRequests: search(query: "(repo:microsoft/playwright OR repo:microsoft/playwright-mcp) state:open no:label is:pr -is:draft", type: ISSUE, first: 100) {
+      pullRequests: search(query: "repo:microsoft/playwright repo:microsoft/playwright-mcp state:open no:label is:pr -is:draft", type: ISSUE, first: 100) {
         nodes {
           ... on PullRequest { ...PullRequestParts }
         }


### PR DESCRIPTION
Update GraphQL queries to search both microsoft/playwright and microsoft/playwright-mcp repositories for issues and pull requests that need triage.

Fixes #16

Generated with [Claude Code](https://claude.ai/code)