### PR TITLE
fix: exclude copilot reviewers from displayed list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,8 @@ export function isMaintainer(login: string) {
 export function isBot(login: string) {
   return [
       "github-actions",
+      "copilot-pull-request-reviewer",
+      "copilot-swe-agent",
   ].includes(login);
 }
 


### PR DESCRIPTION
Fixes #18

This PR excludes copilot reviewers from the displayed list in the triage dashboard:

- Add copilot-pull-request-reviewer to isBot() filter
- Add copilot-swe-agent to isBot() filter

These copilot reviewers will now be filtered out like github-actions, making the reviewer list more focused on human reviewers.

Generated with [Claude Code](https://claude.ai/code)