### PR TITLE
fix: improve assignee display formatting in Ticket component

### DIFF
--- a/src/components/Ticket.astro
+++ b/src/components/Ticket.astro
@@ -40,7 +40,12 @@ const { ticket } = Astro.props;
     <a href={ticket.url} class="item-url">{ticket.url}</a>
     {ticket.assignees.length > 0 && (
       <span class="item-assignees">
-        Assigned to: {ticket.assignees.map(assignee => <a href={`https://github.com/${assignee}`}>@{assignee}</a>)}
+        Assigned to: {ticket.assignees.map((assignee, index) => (
+          <>
+            <a href={`https://github.com/${assignee}`}>@{assignee}</a>
+            {index < ticket.assignees.length - 1 && " "}
+          </>
+        ))}
       </span>
     )}
   </div>


### PR DESCRIPTION
Before

<img width="648" height="98" alt="Screenshot 2025-07-28 at 10 48 25" src="https://github.com/user-attachments/assets/ee1035e2-499a-4114-8a61-cbd7e2e21f92" />

After

<img width="682" height="116" alt="Screenshot 2025-07-28 at 10 49 17" src="https://github.com/user-attachments/assets/c396c093-62f2-4226-be22-16a79ecb6b77" />

(in theory its not @mxschmitt twice, it could be another username.